### PR TITLE
sound: soc: jz4740: fix incorrect bitshifts

### DIFF
--- a/sound/soc/jz4740/jz4740-i2s.c
+++ b/sound/soc/jz4740/jz4740-i2s.c
@@ -403,7 +403,7 @@ static int jz4740_i2s_dai_probe(struct snd_soc_dai *dai)
 	snd_soc_dai_init_dma_data(dai, &i2s->playback_dma_data,
 		&i2s->capture_dma_data);
 
-	if (i2s->version >= JZ_I2S_JZ4780) {
+	if (i2s->version >= JZ_I2S_JZ4770) {
 		conf = (7 << JZ4780_AIC_CONF_FIFO_RX_THRESHOLD_OFFSET) |
 			(8 << JZ4780_AIC_CONF_FIFO_TX_THRESHOLD_OFFSET) |
 			JZ_AIC_CONF_OVERFLOW_PLAY_LAST |


### PR DESCRIPTION
The jz4770 should be configured the same as jz4780 but because of a bug it
was configured like the jz4740 which has different register offsets.

Signed-off-by: Jens Nyberg jens.nyberg@gmail.com
