### PR TITLE
Jz 4.9 wip IPU/framebuffer work

### DIFF
--- a/drivers/video/fbdev/jz4770_fb.c
+++ b/drivers/video/fbdev/jz4770_fb.c
@@ -768,11 +768,6 @@ static int jzfb_pan_display(struct fb_var_screeninfo *var,
 	return 0;
 }
 
-static inline unsigned int words_per_line(unsigned int width, unsigned int bpp)
-{
-	return (bpp * width + 31) / 32;
-}
-
 /*
  * Map screen memory
  */

--- a/drivers/video/fbdev/jz4770_ipu.h
+++ b/drivers/video/fbdev/jz4770_ipu.h
@@ -41,6 +41,7 @@
 #define IPU_OUT_PHY_T_ADDR	0x60 /* Output Physical Table Address Register */
 
 #define IPU_CTRL_ADDR_SEL	BIT(20)		/* address mode selector */
+#define IPU_CTRL_ZOOM_SEL	BIT(18)		/* scale 0:bilinear 1:bicubic */
 #define IPU_CTRL_DFIX_SEL	BIT(17)		/* fixed dest addr */
 #define IPU_CTRL_LCDC_SEL	BIT(11)		/* output to LCDC FIFO */
 #define IPU_CTRL_SPKG_SEL	BIT(10)		/* packed input format */

--- a/drivers/video/fbdev/jz4770_ipu.h
+++ b/drivers/video/fbdev/jz4770_ipu.h
@@ -59,7 +59,9 @@
 #define IPU_IN_GS_W_BIT		0x10
 #define IPU_OUT_GS_H_BIT	0x0
 #define IPU_OUT_GS_W_BIT	0x10
-#define IPU_D_FMT_IN_FMT_BIT	0x0
-#define IPU_D_FMT_OUT_FMT_BIT	0x13
+
+#define IPU_D_FMT_IN_FMT_BIT		0x0
+#define IPU_D_FMT_OUT_FMT_BIT		0x13
+#define IPU_D_FMT_RGB_OUT_OFT_BIT	0x16
 
 #endif /* __JZ4770_IPU_H__ */


### PR DESCRIPTION
- Added bicubic/nearest-neighbor scaling support. This addresses issue https://github.com/gcwnow/linux/issues/1
  (**Reminder for @pcercuei:** remember to reset new sysfs settings 'sharpness_upscaling', 'sharpness_downscaling' to their defaults (both are value 8) in the rootfs script that relaunches Gmenu2X).
- Removed unused old function.
- Added 15bpp screen depth support.
- Added BGR->RGB swizzling support. Also see buildroot PR w/ patch for SDL: https://github.com/gcwnow/buildroot/pull/26